### PR TITLE
Add SyncConfig helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Helper to create SyncConfig objects ([#2])
+
 ### Changed
 
 - Made component open source ([#1]) 
 
 [Unreleased]: https://github.com/projectsyn/component-espejo/compare/7127fc3...HEAD
 [#1]: https://github.com/projectsyn/component-espejo/pull/1
+[#2]: https://github.com/projectsyn/component-espejo/pull/2

--- a/lib/espejo.libsonnet
+++ b/lib/espejo.libsonnet
@@ -1,0 +1,31 @@
+/**
+ * \file espejo.libsonnet
+ * \brief Helpers to create Espejo SyncConfig ojbects.
+ */
+
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local params = inv.parameters.espejo;
+
+/**
+  * \brief Helper to create SyncConfig object.
+  *
+  * Creates a bare bone SyncConfig in the namespace where Espejo is watching them.
+  * Objects of the smae kind in the same namespace must hace uniqe names.
+  * It is suggeted to prefix the name with the name of the component calling it.
+  *
+  * \arg The name of the sync config.
+  * \return A SyncConfig object.
+  */
+local syncConfig(name) = kube._Object('sync.appuio.ch/v1alpha1', 'SyncConfig', name) {
+  'metadata+': {
+    namespace: params.namespace,
+  },
+  spec: {},
+};
+
+{
+  syncConfig: syncConfig,
+}

--- a/lib/espejo.libsonnet
+++ b/lib/espejo.libsonnet
@@ -13,8 +13,8 @@ local params = inv.parameters.espejo;
   * \brief Helper to create SyncConfig object.
   *
   * Creates a bare bone SyncConfig in the namespace where Espejo is watching them.
-  * Objects of the smae kind in the same namespace must hace uniqe names.
-  * It is suggeted to prefix the name with the name of the component calling it.
+  * Objects of the same kind in the same namespace must have unique names.
+  * It is suggested to prefix the name with the name of the component calling it.
   *
   * \arg The name of the sync config.
   * \return A SyncConfig object.


### PR DESCRIPTION
Add a helper to for creating SyncConfig objects. This is needed to have them consistent throughout a cluster and make updating API versions easier.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
