### PR TITLE
Skip dryrun on missing resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Helper to create SyncConfig objects ([#2])
+- Argo CD sync option to skip missing CRDs ([#4])
 
 ### Changed
 
@@ -16,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/projectsyn/component-espejo/compare/7127fc3...HEAD
 [#1]: https://github.com/projectsyn/component-espejo/pull/1
 [#2]: https://github.com/projectsyn/component-espejo/pull/2
+[#4]: https://github.com/projectsyn/component-espejo/pull/4

--- a/lib/espejo.libsonnet
+++ b/lib/espejo.libsonnet
@@ -22,6 +22,9 @@ local params = inv.parameters.espejo;
 local syncConfig(name) = kube._Object('sync.appuio.ch/v1alpha1', 'SyncConfig', name) {
   metadata+: {
     namespace: params.namespace,
+    annotations+: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
   },
   spec: {},
 };


### PR DESCRIPTION
If the CRD was not applied yet, the sync fails otherwise. See [1] for
further details.

[1] https://argoproj.github.io/argo-cd/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.


<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
