### PR TITLE
Update Espejo to v0.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 manifests/
+.idea
+compiled/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,9 @@
 extends: default
 
+ignore: |
+  compiled/
+  manifests/
+
 rules:
   # 80 chars should be enough, but don't fail if a line is longer
   line-length:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Helper to create SyncConfig objects ([#2])
 - Argo CD sync option to skip missing CRDs ([#4])
+- New Parameters that are supported in Espejo from v0.3.0 onward ([#7])
 
 ### Changed
 
 - Made component open source ([#1])
 - Pin version to released tag ([#5])
+- Update Espejo to v0.3.1 ([#7])
 
 [Unreleased]: https://github.com/projectsyn/component-espejo/compare/7127fc3...HEAD
 [#1]: https://github.com/projectsyn/component-espejo/pull/1
 [#2]: https://github.com/projectsyn/component-espejo/pull/2
 [#4]: https://github.com/projectsyn/component-espejo/pull/4
 [#5]: https://github.com/projectsyn/component-espejo/pull/5
+[#7]: https://github.com/projectsyn/component-espejo/pull/7

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,11 +1,25 @@
 parameters:
   espejo:
     namespace: syn-espejo
-    git_tag: v0.0.4
+    git_tag: v0.3.1
     images:
       espejo:
         image: docker.io/vshn/espejo
-        tag: 'v0.0.4@sha256:fc28bc419cc464a96d4519f0e6ef79e7359ee4328d34dc6dc6606260b4348b3f'
+        tag: 'v0.3.1@sha256:a0792c209f41aa17636526e08074b1d6ebe7d452df6260325055a10ddcfa3ea9'
+    resources:
+      limits:
+        cpu: 300m
+        memory: 30Mi
+      requests:
+        cpu: 20m
+        memory: 20Mi
+    args:
+      reconcile-interval: 10m
+      verbose: "false"
+      enable-leader-election: "true"
+      metrics-addr: ":8080"
+
+    extraArgs: []
     cluster_role_rules:
       - apiGroups: ['']
         resources: [namespaces]

--- a/class/espejo.yml
+++ b/class/espejo.yml
@@ -2,8 +2,8 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/vshn/espejo/${espejo:git_tag}/deploy/crds/sync_v1alpha1_syncconfig_crd.yaml
-        output_path: dependencies/espejo/manifests/${espejo:git_tag}/crds/sync_v1alpha1_syncconfig_crd.yaml
+        source: https://github.com/vshn/espejo/releases/download/${espejo:git_tag}/espejo-crd.yaml
+        output_path: dependencies/espejo/manifests/${espejo:git_tag}/crds/espejo-crd.yaml
     compile:
       - input_paths:
           - espejo/component/app.jsonnet

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -26,23 +26,30 @@ local deployment = kube.Deployment('espejo') {
   metadata+: {
     namespace: params.namespace,
     labels: {
-      app: 'espejo',
+      'app.kubernetes.io/name': 'espejo',
+      'app.kubernetes.io/managed-by': 'syn',
     },
   },
   spec+: {
     template+: {
       spec+: {
+        serviceAccountName: service_account.metadata.name,
         containers_+: {
           espejo: kube.Container('espejo') {
             image: params.images.espejo.image + ':' + params.images.espejo.tag,
             env_+: {
               WATCH_NAMESPACE: kube.FieldRef('metadata.namespace'),
-              POD_NAME: kube.FieldRef('metadata.name'),
-              OPERATOR_NAME: 'espejo',
             },
+            args_+: params.args,
+            resources: params.resources,
+            ports: [
+              {
+                name: 'http',
+                containerPort: 8080,
+              },
+            ],
           },
         },
-        serviceAccountName: service_account.metadata.name,
       },
     },
   },


### PR DESCRIPTION
Updates Espejo. Since the rewrite with Operator-SDK with 1.1 Espejo supports new flags and env vars.

A rollout on a cluster is not tested yet.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
