### PR TITLE
Add RBAC rule to allow interacting with Leases for leader election

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,5 +28,6 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           body: ${{steps.build_changelog.outputs.changelog}}
+          prerelease: "${{ contains(github.ref, '-rc') }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -22,7 +22,7 @@ parameters:
     extraArgs: []
     cluster_role_rules:
       - apiGroups: ['']
-        resources: [namespaces]
+        resources: [namespaces, namespaces/status]
         verbs:
           - get
           - list
@@ -45,4 +45,7 @@ parameters:
         verbs: ['*']
       - apiGroups: [extensions]
         resources: [networkpolicies]
+        verbs: ['*']
+      - apiGroups: [coordination.k8s.io]
+        resources: [leases]
         verbs: ['*']


### PR DESCRIPTION
Espejo with leader election enabled was not able to actually elect a leader, due to a missing RBAC rule.

See https://github.com/vshn/espejo/issues/102

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
