### PR TITLE
Add cluster-monitoring label to espejo namespace

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -6,7 +6,13 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.espejo;
 
-local namespace = kube.Namespace(params.namespace);
+local namespace = kube.Namespace(params.namespace) {
+  metadata+: {
+    labels+: {
+      'openshift.io/cluster-monitoring': 'true',
+    },
+  },
+};
 
 local cluster_role = kube.ClusterRole('syn-espejo') {
   rules: params.cluster_role_rules,

--- a/tests/golden/defaults/espejo/espejo/01_namespace.yaml
+++ b/tests/golden/defaults/espejo/espejo/01_namespace.yaml
@@ -4,4 +4,5 @@ metadata:
   annotations: {}
   labels:
     name: syn-espejo
+    openshift.io/cluster-monitoring: 'true'
   name: syn-espejo


### PR DESCRIPTION
We should
a) monitor if espejo is running
b) include the namespace in the cluster infra monitoring (e.g. for filtering with namespace selector in mutating webhooks)

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
